### PR TITLE
Add adaptive averaging to pna_control

### DIFF
--- a/fit_resonator/samples/user_example.py
+++ b/fit_resonator/samples/user_example.py
@@ -15,7 +15,9 @@ np.set_printoptions(precision=4,suppress=True)# display numbers with 4 sig. figu
                          ## Code Starts Here ##
 
 dir = '/Users/coreyraemcrae/Documents/GitHub/data/epi-GaAs_LEres/GaAs_Die1/BlueFors/4p792GHz/2019_08_22_11_36_20_highpowersweep/' #make sure to use / instead of \
-filename = 'VNA_3_formatted.csv'
+dir = '/Users/Lehnert Lab/GitHub/measurement/temperature_control/powersweep_220617_11_56_17'
+#make sure to use / instead of \
+filename = 'M3D6_03_BARE_220617_7_-15dB_300000000_mKpcsv.csv'
 
 #############################################
 ## create Method
@@ -24,6 +26,7 @@ fit_type = 'DCM'
 MC_iteration = 10
 MC_rounds = 1e3
 MC_fix = ['w1']
+MC_fix = []
 #manual_init = [Qi,Qc,freq,phi]        #make your own initial guess: [Qi, Qc, freq, phi] (instead of phi used Qa for CPZM)
 manual_init = None # find initial guess by itself
 

--- a/pna_control/pna_control.py
+++ b/pna_control/pna_control.py
@@ -99,7 +99,9 @@ def get_data(centerf: float,
             ifband: float = 5, 
             points: int = 201, 
             outputfile: str = "results.csv",
-            instr_addr : str = 'GPIB::16::INSTR',
+            # instr_addr : str = 'GPIB::16::INSTR',
+            # instr_addr : str = 'TCPIP0::69.254.35.52::islip0::INSTR1',
+            instr_addr : str = 'TCPIP0::K-N5222B-21927::hislip0,4880::INSTR',
             sparam : str = 'S12'):
     '''
     function to get data and put it into a user specified file
@@ -159,8 +161,9 @@ def power_sweep(startpower: float,
                 ifband: float = 5, 
                 points: int = 201, 
                 outputfile: str = "results.csv",
-                meastype: str = None,
-                sparam : str = 'S12'):
+                meastype: str = 'powersweep',
+                sparam : str = 'S12',
+                adaptive_averaging : bool = True):
     '''
     run a power sweep for specified power range with a certain number of sweeps
     '''
@@ -171,7 +174,7 @@ def power_sweep(startpower: float,
     print(f'Measuring {sparam} ...')
 
     #create a new directory for the output to be put into
-    directory_name = timestamp_folder(os.getcwd(),meastype)
+    directory_name = timestamp_folder(os.getcwd(), meastype)
     os.mkdir(directory_name)
     outputfile = directory_name + '/' + outputfile
 
@@ -192,9 +195,10 @@ def power_sweep(startpower: float,
     #run each sweep
     for i in sweeps:
         print(f'{i} dBm, {averages//1} averages ...')
-        getdata(centerf, span, temp, averages, i, edelay, ifband, points,
+        get_data(centerf, span, temp, averages, i, edelay, ifband, points,
                 outputfile, sparam=sparam)
-        averages = averages * ((10**(stepsize/10))**0.5)
+        if adaptive_averaging: 
+            averages = averages * ((10**(stepsize/10))**0.5)
     print('Power sweep completed.')
 
 

--- a/temperature_control/janis_ctrl.py
+++ b/temperature_control/janis_ctrl.py
@@ -57,13 +57,15 @@ class JanisCtrl(object):
 
         # Set as True to start the PID controller, then set to False to allow
         # for updates to the PID values from the previous temperature set point
-        self.is_pid_init = True
-        self.pid_values  = None
+        self.is_pid_init  = True
+        self.pid_values   = None
+        self.bypass_janis = False
 
         # Default thermalization time
         self.therm_time  = 300. # Wait extra 5 minutes to thermalize [s]
         self.T_eps       = 1e-2 # Temperature settling threshold [mK]
         self.T_sweep_list_spacing = 'linear'
+        self.adaptive_averaging = False
 
         # Set the base temperature of the fridge here
         self.T_base = 0.016
@@ -80,9 +82,12 @@ class JanisCtrl(object):
             setattr(self, k, v)
 
         # Create socket connection to the Janus Gas Handling System
-        if self.init_socket:
+        print(f'self.bypass_janis: {self.bypass_janis}')
+        if self.init_socket and (not self.bypass_janis):
             self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             self.socket.connect((self.TCP_IP, self.TCP_PORT))
+        elif self.bypass_janis:
+            self.socket = None
         else:
             self.socket = None
 
@@ -492,15 +497,52 @@ class JanisCtrl(object):
         out['PID']      = [P, I, D]
         out[flo_key]    = flow
         fid.write(f'{tsout}, {tout}, {Tout}, {Iout}, {P}, {I}, {D}, {flow}\n')
+
+
+    def estimate_init_adaptive_averages(
+            self,
+            time_per_sweep : float, 
+            powers : np.ndarray,
+            total_time_hr : float) -> int:
+        """
+        Estimates the initial number of averages used by the adaptive averaging
+        performed by power_sweep
+    
+        Arguments:
+        ---------
+    
+        time_per_sweep:     time to perform 1 average [s]
+        powers:             array of powers in the power sweep [dBm]
+        total_time_hr:      total runtime [hr]
+    
+        """
+        # Check that adaptive averaging is active
+        assert self.adaptive_averaging, 'Adaptive averaging not set!'
+
+        # Compute the step size and number of points
+        stepsize = abs(powers[1] - powers[0])
+        print(f'stepsize: {stepsize}')
+        Npts = len(powers)
+        fac = (10**(stepsize/10))**0.5
+        print(f'fac: {fac}')
+        sec2hr = 3600.
+    
+        # Compute the number of averages
+        Navg = total_time_hr / sum([time_per_sweep * fac**i / sec2hr
+                                    for i in range(Npts)])
+    
+        return int(np.ceil(Navg))
     
 
-    def pna_process(self, idx, Tset, out, prefix='M3D6_02_WITH_1SP_INP'):
+    def pna_process(self, idx, Tset, out, prefix='M3D6_02_WITH_1SP_INP',
+                    adaptive_averaging=True):
         """
         Performs a PNA measurement
         """
         # Get the temperature from the temperature controller
         temp = Tset * 1e3 #mk
         sampleid = f'{prefix}_{self.dstr}' 
+        pstr = f'{prefix}_{int(self.vna_startpower)}_{int(self.vna_endpower)}dBm'
 
         # Preparing to measure frequencies, powers
         powers = np.linspace(self.vna_startpower, self.vna_endpower,
@@ -516,10 +558,12 @@ class JanisCtrl(object):
         # four characters and removes them when manipulating strings and
         # directories
         outputfile = sampleid+'_'+str(self.vna_centerf)+'GHz.csv'
-        PNA.powersweep(self.vna_startpower, self.vna_endpower,
+        PNA.power_sweep(self.vna_startpower, self.vna_endpower,
                 self.vna_numsweeps, self.vna_centerf, self.vna_span, temp,
                 self.vna_averages, self.vna_edelay, self.vna_ifband,
-                self.vna_points, outputfile, sparam=self.sparam)
+                self.vna_points, outputfile, sparam=self.sparam, 
+                meastype=pstr,
+                adaptive_averaging=adaptive_averaging)
 
         out[idx] = 0
 
@@ -738,92 +782,28 @@ if __name__ == '__main__':
     Jctrl = JanisCtrl(Tstart, Tstop, dT,
             sample_time=sample_time, T_eps=T_eps,
             therm_time=therm_time,
-            init_socket=True)
+            # init_socket=True, bypass_janis=True)
+            init_socket=True, bypass_janis=False)
 
-    # Setup for the VNA controller
-    Jctrl.sparam = 'S12'
-    Jctrl.vna_edelay = 76.983 #ns
-    Jctrl.vna_ifband = 1.0 # kHz
-    # 1SP InP
-    # Jctrl.vna_centerf = 7.58967
-    # 2SP InP
-    # Jctrl.vna_centerf = 8.01385
-    # # Mines 3D #1, bare
-    # Jctrl.vna_centerf = 9.23069
-    # Jctrl.vna_span = 0.75 # MHz
-    # Jctrl.vna_edelay = 77.62 #ns
-    # Mines 3D #2, bare
-    Jctrl.vna_centerf = 4.22383
-    Jctrl.vna_span = 0.2 # MHz
-    Jctrl.vna_edelay = 60.93 #ns
-    # # NYU 2D Al on InP
-    # Jctrl.vna_edelay = 76.635 #ns
-    # Jctrl.vna_centerf = 7.7182
-    # Jctrl.vna_span = 15 # MHz
+    # Mines 3D #3, bare
+    Jctrl.vna_centerf = 8.0214305
+    Jctrl.vna_span = 0.5 # MHz
+    # Jctrl.vna_edelay = 0.969 #ns
+    Jctrl.vna_edelay = 1.039 #ns
+
     Jctrl.vna_points = 1001
 
     # Temperature sweep settings
     Jctrl.sparam = 'S12'
 
     # First sweep, int power
-    Jctrl.vna_averages = 10000
-    Jctrl.vna_ifband = 1.0 #khz
-    Jctrl.vna_numsweeps = 2 
-    Jctrl.vna_startpower = -95
-    Jctrl.vna_endpower = -95
-
-    # Second sweep, intermediate power
-    # Jctrl.vna_averages = 3
-    # Jctrl.vna_ifband = 10 #khz
-    # Jctrl.vna_numsweeps = 3
-    # Jctrl.vna_startpower = -5
-    # Jctrl.vna_endpower = -15
-    # Jctrl.vna_centerf = 4.224
-    # Jctrl.vna_span = 1000. # MHz
-    # Jctrl.vna_points = 32001
-
-    # # Third sweep, low power
-    # Jctrl.vna_averages = 1000
-    # Jctrl.vna_ifband = 0.05 #khz
-    # Jctrl.vna_numsweeps = 4
-    # Jctrl.vna_startpower = -80
-    # Jctrl.vna_endpower = -95
-
-    # # Fast test sweep, low power
-    # Jctrl.vna_averages = 3
-    # Jctrl.vna_ifband = 1 #khz
-    # Jctrl.vna_numsweeps = 2 
-    # Jctrl.vna_startpower = -30
-    # Jctrl.vna_endpower = -35
-
-    # # High power sweep
-    # Jctrl.vna_averages = 10
-    # Jctrl.vna_ifband = 1.0 #khz
-    # Jctrl.vna_numsweeps = 7
-    # Jctrl.vna_startpower = -35
-    # Jctrl.vna_endpower = -5
-
-    # # Intermediate power sweep #2
-    # Jctrl.vna_averages = 100
-    # Jctrl.vna_ifband = 1.0 #khz
-    # Jctrl.vna_numsweeps = 8
-    # Jctrl.vna_startpower = -50
+    Jctrl.vna_averages = 5000
+    Jctrl.vna_ifband = 0.1 #khz
+    Jctrl.vna_numsweeps = 3
+    # Jctrl.vna_startpower = -70
     # Jctrl.vna_endpower = -85
-
-    # # Low power sweep #1
-    # Jctrl.vna_averages = 1500
-    # Jctrl.vna_ifband = 0.150 #khz
-    # Jctrl.vna_numsweeps = 2
-    # Jctrl.vna_startpower = -90
-    # Jctrl.vna_endpower = -95
-
-    # # Low power sweep
-    # Jctrl.vna_edelay = 78.056
-    # Jctrl.vna_averages = 2000 
-    # Jctrl.vna_ifband = 0.1 #khz
-    # Jctrl.vna_numsweeps = 2 
-    # Jctrl.vna_startpower = -90
-    # Jctrl.vna_endpower = -95
+    Jctrl.vna_startpower = -85
+    Jctrl.vna_endpower = -95
 
     Jctrl.print_class_members()
 
@@ -837,25 +817,11 @@ if __name__ == '__main__':
     Jctrl.read_pressure('all')
 
     # Mines 3D cavity 9.2 GHz with, without InP
-    # sample_name = 'M3D6_02_WITH_2SP_INP'
-    # sample_name = 'M3D6_02_BARE'
+    sample_name = 'M3D6_02_WITH_2SP_INP'
+    out = {}
+    Jctrl.pna_process('meas', T, out, prefix=sample_name,
+                    adaptive_averaging=True)
 
-    # # Mines 3D cavity 7.6 GHz with, without InP
-    sample_name = 'M3D6_03_BARE'
-    # # NYU 2D resonator, Al on InP
-    # sample_name = 'NYU2D_AL_INP'
-
-    # # Rigetti Reference Wafer 1, Die 1
-    sample_name = 'RGREF01_01'
-    # out = {}
-    # Jctrl.pna_process('meas', T, out, prefix=sample_name)
-
-    # Rigetti Reference Wafer 1, Die 1 -- all resonators
-    # multiple_resonator_driver(Jctrl)
-
-    # sample_name = 'M3D6_02_WITH_2SP_INP'
-    # sample_name = 'M3D6_02_BARE'
-    # sample_name = 'M3D6_03_BARE'
     # NYU 2D resonator, Al on InP
     # sample_name = 'NYU2D_AL_INP'
     # Jctrl.run_temp_sweep(measure_vna=True, prefix=sample_name)

--- a/temperature_control/user_ctrl.py
+++ b/temperature_control/user_ctrl.py
@@ -1,0 +1,95 @@
+# -*- encoding: utf-8 -*-
+"""
+User file for controlling the Janis and PNA instruments
+"""
+
+from janis_ctrl import JanisCtrl
+import numpy as np
+
+"""
+Temperature sweep settings
+"""
+# Example inputs to run a temperature sweep
+# Iterate over a list of temperatures
+# 30 mK -- 300 mK, 10 mK steps
+Tstart = 0.03; Tstop = 0.315; dT = 0.015
+sample_time = 15; T_eps = 0.0025 # -- 255 mK and up
+therm_time  = 300. # wait an extra 5 minutes to thermalize
+
+# Setup the temperature controller class object
+## Note: bypass_janis runs the JanisCtrl class without
+##       communicating with the JACOB and can only
+##       perform measurements with the PNA
+adaptive_averaging = True
+Jctrl = JanisCtrl(Tstart, Tstop, dT,
+        sample_time=sample_time, T_eps=T_eps,
+        therm_time=therm_time,
+        init_socket=True, bypass_janis=False,
+        adaptive_averaging=adaptive_averaging)
+
+"""
+Change these settings for each power sweep
+"""
+# Set the PNA inputs for the power sweep
+Jctrl.vna_centerf = 6.23698 # GHz
+Jctrl.vna_centerf = 8.02143 # GHz
+Jctrl.vna_span = 0.5 # MHz
+Jctrl.vna_edelay = 0.923 #ns
+Jctrl.vna_points = 1001
+Jctrl.sparam = 'S12'
+Jctrl.vna_ifband = 0.1 #khz
+Jctrl.vna_startpower = -88 # dBm
+Jctrl.vna_endpower = -89 # dBm
+Jctrl.vna_numsweeps = 2
+time_per_sweep = 10.
+powers = np.linspace(Jctrl.vna_startpower,
+                    Jctrl.vna_endpower,
+                    Jctrl.vna_numsweeps)
+print(f'powers: {powers}')
+total_time_hr = 24.
+Navg_adaptive = Jctrl.estimate_init_adaptive_averages(
+                    time_per_sweep, 
+                    powers,
+                    total_time_hr)
+print(f'Number of averages: {Navg_adaptive}')
+# Jctrl.vna_averages = 1000
+Jctrl.vna_averages = Navg_adaptive
+# sample_name = 'RGSI002_A1g7_6p23698_GHz'
+sample_name = 'M3D6_02_WITH_2SP_INP'
+
+# Print the JanisCtrl class members
+Jctrl.print_class_members()
+
+# Set the MXC current to 0 mA
+Jctrl.set_current(0.)
+
+# Read the MXC temperature from the CMN
+Z, T, tstamp = Jctrl.read_cmn()
+print(f'{tstamp}, {Z} ohms, {T*1e3} mK')
+
+# Read the flow rate
+flow_V, flow_umol_s1, tstamp = Jctrl.read_flow_meter()
+print(f'{tstamp}, {flow_V} V, {flow_umol_s1} umol / s')
+
+# Read and report all temperatures a pressures
+Jctrl.read_temp('all')
+Jctrl.read_pressure('all')
+
+# Enter a sample name and perform the PNA power sweep
+## Note: adaptive_averaging will increase the averages
+##       by a factor 10^(dp / 10), where dp is the power
+##       step in the power sweep -- ~1.7 for dp = 5 dBm
+out = {}
+Jctrl.pna_process('meas', T, out, prefix=sample_name,
+                adaptive_averaging=adaptive_averaging)
+
+"""
+Temperature sweep, comment out the pna_process above
+"""
+# Jctrl.run_temp_sweep(measure_vna=True, prefix=sample_name)
+
+# Set the MXC heat to 0 mA just to be safe
+# and report the temperature on the CMN before exiting
+Jctrl.set_current(0.)
+Z, T, tstamp = Jctrl.read_cmn()
+print(f'{tstamp}, {Z} ohms, {T*1e3} mK')


### PR DESCRIPTION
Add user_ctrl.py to handle PNA, temperature ctrl

This separates user code from library code
And gives a minimal working example for users

Add adaptive average time estimate

Estimates the number of initial averages
This is useful for long power sweeps
To set a target time to finish a run
Coauthors: Svetlana Doroshevich, Kyle Thompson
Summer 2022 SPUR research assistants