### PR TITLE
reonsator.py rewrite, README rewrites, Addresses (#98), 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,12 @@
 # scresonators
 Welcome to the scresonators repository of the Boulder Cryogenic Quantum Testbed! This is a library for measuring the loss in superconducting resonators. 
 
-## Installation
+
+## Importing the Library
+1. Install the library and its relevant dependencies with `pip install scresonators-fit`
+2. Lead your python code with `import fit_resonator.resonator as resonator`
+
+## Contributing/Modifying
 1. clone the repository into a folder of your choice with `git clone https://github.com/Boulder-Cryogenic-Quantum-Testbed/scresonators.git`
 2. Install the dependencies, we ***strongly*** recommend using [virtual environments](https://packaging.python.org/guides/installing-using-pip-and-virtual-environments/) for managing your dependences. To install dependencies run:
   `pip install -r requirements.txt`
@@ -9,33 +14,39 @@ Welcome to the scresonators repository of the Boulder Cryogenic Quantum Testbed!
  
 ## Using the library
 
+Fitting resonator data will revolve around the resonator class.
+
 Here's an example using some of the data hosted on this repository. Hosted
 datasets from groups around the world can be found [here](/cryores/test_data).
 
-This particular example code is meant to be run in the root directory.
-
 ```python
 import numpy as np
-import fit_resonator.functions as ff
-import fit_resonator.Sdata as fsd
-import fit_resonator.resonator as res
+import fit_resonator.resonator as scres
 
+# The object all following code will be called from
+my_resonator = scres.Resonator()
+
+# Load the raw data
 url = 'https://raw.githubusercontent.com/Boulder-Cryogenic-Quantum-Testbed/scresonators/master/cryores/test_data/AWR/AWR_Data.csv'
-
-# Load the raw data:
 raw = np.loadtxt(url, delimiter=',')
+# Can also use our file input system of my_resonator.from_file(url)
 
-# Choose a fitting method:
+# Test with file load into class
+my_resonator.from_columns(raw)
+
+# Assign your desired fit method variables
 fit_type = 'DCM'
 MC_iteration = 10
 MC_rounds = 1e3
 MC_fix = ['w1']
 manual_init = None
-method = res.FitMethod(fit_type, MC_iteration, MC_rounds=MC_rounds,
-                       MC_fix=MC_fix, manual_init=manual_init, MC_step_const=0.3)
 
-# Fit the data:
-fsd.fit("output test", method, normalize=10, data_array=raw)
+# Pass these to your resonator object
+my_resonator.fit_method(fit_type, MC_iteration, MC_rounds=MC_rounds, MC_fix=MC_fix, manual_init=manual_init,
+                 MC_step_const=0.3)
+
+# Fit!
+my_resonator.fit()
 ```
 
 Ane in depth description is given in the fit_resonators folder.
@@ -43,6 +54,6 @@ Ane in depth description is given in the fit_resonators folder.
 
 ## Code Organization
 
-Until the module is officially distributed, all code should live in the `fit_resonator` namespace. This ensures easy integration
+For fitting code collaboration, all code should live in the `fit_resonator` namespace. This ensures easy integration
 with other Python packages, and avoids name collisions; everything is referred
 to as e.g. `fit_resonator.experiments` rather than just `experiments`.

--- a/fit_resonator/README.md
+++ b/fit_resonator/README.md
@@ -99,19 +99,16 @@ Must install pip module before installing pips for python 2. Once pip is install
 
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-## USER INPUT FILE
+## Using the code
 
-###### An example of the way the following is done is included in the example file (User_Example.py)
+###### An example of the way the following is done is included in the main README
 
 #### Section 1: Initial Setup
 
-###### The user will need to set the "dir" variable equal to the directory of folder containing user file. This can be done with the command:
-
-`dir = "your path to data folder here"`
-
-###### User will need to set the "filename" variable to the name of their file with:
-`filename = 'your name here.csv'`
+###### User will need to set a variable with the name of their file:
+`filename = 'your name here.csv/txt/snp'`
    >Note that code accepts both .txt and .csv file formats
+###### OR have a variable containing their raw data
 
 #### Section 2: Setting Fit Variables
 
@@ -150,19 +147,49 @@ MC_step_const: Range for the random parameter values chosen in MC fit. This scal
 
 #### Section 3: Fitting Data
 
-The user calls the Fit_Resonator function with:
+Import code library with:
+`import fit_resonator.resonator as scres`
 
-`params1,fig1,chi1,init1 = fsd.Fit_Resonator(filename = filename,Method = Method,normalize = normalize,dir = dir)`
+Initialize resonator object with:
+`my_resonator = scres.Resonator()`
 
-If the user wants to have the code remove their background, they need to include the path to their background removal file as well with:
+Initialize raw data or file into resonator object with:
+`my_resonator.from_columns(raw_data)`
+`my_resonator.from_file(filename)`
 
-`params1,fig1,chi1,init1 = Fit_Resonator(filename = filename,Method = Method,normalize = normalize,dir = dir,background = background_file)`
+You can also pass the data as a filename or data object when initializing your resonator object with:
+`my_resonator = scres.Resonator(filepath='PATH/TO/FILE')`
+`my_resonator = scres.Resonator(data=raw_data)`
 
-   >Here it is assumed that dir is the same directory for both the user's main data file and the background and can thus be used for both
+If you're using a snp file with more than three columns please specify to the resonator object which value to use with:
+`my_resonator.from_file('PATH/TO/FILE.snp', "S12")`
+`my_resonator = scres.Resontor(filepath='PATH/TO/FILE.snp', measurement="S12"`
+or with the index value(s)
+`my_resonator.from_file('PATH/TO/FILE.snp', [2,3])`
+`my_resonator = scres.Resontor(filepath='PATH/TO/FILE.snp', measurement=[2,3]`
+
+
+Define the parameters of your fitting method with:
+my_resonator.fit_method(method: str,
+MC_iteration=None,
+MC_rounds=100,
+MC_weight='no',
+MC_weightvalue=2,
+MC_fix=[],
+MC_step_const=0.6,
+manual_init=None):)
+
+Call the fitting function once resonator class hold all relevant information with:
+`params1,fig1,chi1,init1 = my_resonator.fit()`
+
+If the user wants to have the code remove their background, they need to include the path to their background removal file in resonator object initialization with:
+`my_resonator = scres.Resonator(background = background_file)`
 
 normalize: The number of points from the start/end of S21 data the user wants to use in the linear fit of S21 data for magnitude and phase for normalization, set with:
+`my_resonator = scres.Resonator(background = background_file)`
 
-`normalize = 10`
+Remember for these special initializations you can include as many as you need, just don't forget the keyword arguments!
+`my_resonator = scres.Resonator(background = background_file, normalize = 5, filepath = "PATH/TO/FILE, measurement = "S21"`
 
 ##Check Data:
 

--- a/fit_resonator/README.md
+++ b/fit_resonator/README.md
@@ -104,10 +104,9 @@ Must install pip module before installing pips for python 2. Once pip is install
 ###### An example of the way the following is done is included in the main README
 
 #### Section 1: Initial Setup
-
+Import code library with:
+`import fit_resonator.resonator as scres`
 ###### User will need to set a variable with the name of their file:
-`filename = 'your name here.csv/txt/snp'`
-   >Note that code accepts both .txt and .csv file formats
 ###### OR have a variable containing their raw data
 
 #### Section 2: Setting Fit Variables
@@ -146,9 +145,6 @@ manual_init: Used to define initial guess variables
 MC_step_const: Range for the random parameter values chosen in MC fit. This scaling is exponential. The larger this number, the higher and lower the random values
 
 #### Section 3: Fitting Data
-
-Import code library with:
-`import fit_resonator.resonator as scres`
 
 Initialize resonator object with:
 `my_resonator = scres.Resonator()`

--- a/fit_resonator/Sdata.py
+++ b/fit_resonator/Sdata.py
@@ -2,24 +2,19 @@ import attr
 import numpy as np
 import lmfit
 import matplotlib.pyplot as plt
-import pandas as pd
 from matplotlib.gridspec import GridSpec
-import sympy as sym
 from scipy.optimize import curve_fit
 from matplotlib.patches import Circle
 from lmfit import Minimizer
 import inflect
 import matplotlib.pylab as pylab
-from scipy import optimize
 from scipy import stats
 import time
 import sys
 import os
-import skrf as rf
 
 import logging
 import scipy.optimize as spopt
-from scipy.interpolate import splrep, splev
 from scipy.ndimage.filters import gaussian_filter1d
 from scipy.interpolate import interp1d
 import fit_resonator.functions as ff
@@ -1850,7 +1845,7 @@ def fit(resonator):
         '''except:
             print(">Failed to plot DCM fit for data")
             quit()'''
-    if Method.method == 'PHI':
+    elif Method.method == 'PHI':
         try:
             title = 'PHI fit for ' + filename
             figurename = "PHI with Monte Carlo Fit and Raw data\nPower: " + filename
@@ -1861,7 +1856,7 @@ def fit(resonator):
         except:
             print(">Failed to plot PHI fit for data")
             quit()
-    if Method.method == 'DCM REFLECTION':
+    elif Method.method == 'DCM REFLECTION':
         try:
             title = 'DCM REFLECTION fit for ' + filename
             figurename = " DCM REFLECTION with Monte Carlo Fit and Raw data\nPower: " + filename

--- a/fit_resonator/resonator.py
+++ b/fit_resonator/resonator.py
@@ -3,7 +3,6 @@ import datetime
 import attrs
 import attr
 import numpy as np
-from matplotlib import pyplot as plt
 
 import fit_resonator.functions as ff
 import fit_resonator.Sdata as fs

--- a/fit_resonator/test/fit_S_data_test.py
+++ b/fit_resonator/test/fit_S_data_test.py
@@ -70,12 +70,12 @@ def test_extract_near_res():
         fsd.extract_near_res(freqs, amps, f_res, kappa)
 
 def test_data_input():
-    filepath = 'C:/1work/Research/snp_examples/M3D6_WTH_2SP_INP_-35dBm_19mK_220706.s2p'
+    filepath = '.s2p'
     data = fsd.VNASweep.from_file(filepath, "S21")
     print(data)
 
 def test_data_fit():
-    filepath = 'C:/1work/Research/snp_examples/M3D6_WTH_2SP_INP_-35dBm_19mK_220706.s2p'
+    filepath = '.s2p'
     fit_type = 'DCM'
     MC_iteration = 10
     MC_rounds = 1e3

--- a/fit_resonator/test/resonator_test.py
+++ b/fit_resonator/test/resonator_test.py
@@ -35,7 +35,7 @@ def test_simple():
     reson = res.Resonator()
 
     # Test with file load into class
-    reson.from_file("C:/1work/Research/snp_examples/M3D6_WTH_2SP_INP_-35dBm_19mK_220706.s2p", "s12")
+    reson.from_file(".s2p", "s12")
     fit_type = 'DCM'
     MC_iteration = 10
     MC_rounds = 1e3
@@ -46,21 +46,29 @@ def test_simple():
 
     # Test with file provided in fit call
     reson.fit()
-    # reson.fit("C:/1work/Research/snp_examples/M3D6_WTH_2SP_INP_-35dBm_19mK_220706.s2p", measurement="s12")
 
 
 def test_raw_res():
+    # The object all following code will be called from
+    my_resonator = res.Resonator()
+
+    # Load the raw data
     url = 'https://raw.githubusercontent.com/Boulder-Cryogenic-Quantum-Testbed/scresonators/master/cryores/test_data/AWR/AWR_Data.csv'
     raw = np.loadtxt(url, delimiter=',')
 
-    reson = res.Resonator(data=raw)
+    # Test with file load into class
+    my_resonator.from_columns(raw)
 
+    # Assign your desired fit method variables
     fit_type = 'DCM'
     MC_iteration = 10
     MC_rounds = 1e3
     MC_fix = ['w1']
     manual_init = None
 
-    reson.fit_method(fit_type, MC_iteration, MC_rounds=MC_rounds, MC_fix=MC_fix, manual_init=manual_init,
+    # Pass these to your resonator object
+    my_resonator.fit_method(fit_type, MC_iteration, MC_rounds=MC_rounds, MC_fix=MC_fix, manual_init=manual_init,
                      MC_step_const=0.3)
-    reson.fit()
+
+    # Fit!
+    my_resonator.fit()


### PR DESCRIPTION
-Rewriting of Resonator class as data container for all necessary fitting values.
     Users will now initialize a Resonator class object, then use that object for preparing fitting variables, and running the fit itself.
-Lmfit warning (#98) and related inaccurate confidence interval reporting bug fixed
     lmfit is only passed non-fixed variables now.
     Will look into cleaning up the logic of the confidence interval calculation if time permits