### PR TITLE
Implement Dependabot to automatically keep dependencies updated

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -54,10 +54,12 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+
   - package-ecosystem: "scikit" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+
   - package-ecosystem: "uncertainties" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,64 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "attr" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+      
+  - package-ecosystem: "inflect" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+      
+  - package-ecosystem: "lmfit" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+      
+  - package-ecosystem: "matplotlib" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+      
+  - package-ecosystem: "numpy" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+      
+  - package-ecosystem: "pandas" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+      
+  - package-ecosystem: "pylabrad" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "pytest" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "scipy" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "sympy" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "scikit" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "uncertainties" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
If the wheels have been properly updated, this should close #155 

Dependabot updates will need to be enabled on the main repository. This can be done by going to "Settings" and under "Code security and analysis", to the right of "Dependabot version updates", click Enable to allow Dependabot to initiate version updates.