### PR TITLE
Bring back pylint because I like it better than lint8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@
 # It will also test install scresonators-fit with pip
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
-name: Python package
+name: tests
 
 on:
   push:
@@ -28,14 +28,12 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install flake8 pytest
+        pip install pylint
+        pip install pytest
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-    - name: Lint with flake8
+    - name: Lint with pylint
       run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        pylint $(git ls-files '*.py')
     - name: Test with pytest
       run: |
         pytest

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ scresonators-fit: fitting superconducting resonator data using Python
 ===========================================
 
 [![CodeFactor](https://www.codefactor.io/repository/github/boulder-cryogenic-quantum-testbed/scresonators/badge/master)](https://www.codefactor.io/repository/github/boulder-cryogenic-quantum-testbed/scresonators/overview/master)
-![pytest](https://github.com/boulder-cryogenic-quantum-testbed/scresonators/actions/workflows/python-package.yml/badge.svg)
+![Tests](https://github.com/boulder-cryogenic-quantum-testbed/scresonators/actions/workflows/python-package.yml/badge.svg)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 scresonators code is made to fit complex S21 data for hangar mode resonators. The scresonators library supports fitting using the Diameter Correction Method (DCM), Inverse S21 method (INV), Closest Pole and Zero Method (CPZM), and Phi Rotation Method (PHI). Additionally, the code is able to fit reflection type geometry resonators with an altered version of the Diameter Correction Method (DCM REFLECTION).
@@ -37,11 +37,13 @@ Citation
 --------
 If you use scresonators to fit data or generate plots used in a publication you can cite it as follows:
 
->  @misc{scresonators,
->    title        = {{boulder-cryogenic-quantum-testbed/scresonators}},
->    year         = 2023,
->    howpublished = {\url{https://github.com/Boulder-Cryogenic-Quantum-Testbed/scresonators}}
->  }
+```latex
+@misc{scresonators,
+  title        = {{boulder-cryogenic-quantum-testbed/scresonators}},
+  year         = 2023,
+  howpublished = {\url{https://github.com/Boulder-Cryogenic-Quantum-Testbed/scresonators}}
+}
+```
 
 
 


### PR DESCRIPTION
Use pylint in the testing workflow and fix appearance of citation in README.