### PR TITLE
Changing linter and protocall

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,4 +36,4 @@ jobs:
         pytest
     - name: Lint with pylint
       run: |
-        pylint $(git ls-files '*.py') --disable=all
+        find . -type f -name "*.py" | xargs pylint --disable=all

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,6 @@ jobs:
         pytest
     - name: Lint with flake8
       run: |
-        mamba install flake8
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,12 +28,16 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pylint
+        pip install flake8
         pip install pytest
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Test with pytest
       run: |
         pytest
-    - name: Lint with pylint
+    - name: Lint with flake8
       run: |
-        find . -type f -name "*.py" | xargs pylint --disable=all
+        mamba install flake8
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ If you use scresonators to fit data or generate plots used in a publication you 
 ```latex
 @misc{scresonators,
   title        = {{boulder-cryogenic-quantum-testbed/scresonators}},
-  year         = 2023,
+  year         = {2023},
   howpublished = {\url{https://github.com/Boulder-Cryogenic-Quantum-Testbed/scresonators}}
 }
 ```


### PR DESCRIPTION
Pylint was failing to find python files and was also pointless being run with --disable=all. Flake 8 allows for errors only at critical syntax issues.